### PR TITLE
chore: add claude-global-config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ next-env.d.ts
 # Playwright E2E test reports and results - should not be committed
 playwright-report/
 test-results/
+
+# Ignore other repositories that might be accidentally copied here
+claude-global-config/


### PR DESCRIPTION
## Summary
- Added `claude-global-config/` to `.gitignore` to prevent accidental inclusion of external repositories
- This prevents the "embedded git repository" warning when running `git add .`

## Context
The `claude-global-config` repository was accidentally copied into this project directory, causing git to warn about embedded repositories. This change ensures it won't be tracked if it accidentally appears in the project directory again.

## Changes
- Updated `.gitignore` to exclude `claude-global-config/` directory

## Test Plan
- [x] Verified `.gitignore` properly excludes the directory
- [x] Confirmed no other unintended changes
- [x] Tested that git no longer attempts to track `claude-global-config/`

🤖 Generated with [Claude Code](https://claude.ai/code)